### PR TITLE
Optional Chrono

### DIFF
--- a/.github/workflows/circadian-tools-build.yml
+++ b/.github/workflows/circadian-tools-build.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Run cargo test
       uses: actions-rs/cargo@v1
       with:
-        command: test --all-features
+        command: test

--- a/.github/workflows/circadian-tools-build.yml
+++ b/.github/workflows/circadian-tools-build.yml
@@ -36,4 +36,4 @@ jobs:
     - name: Run cargo test
       uses: actions-rs/cargo@v1
       with:
-        command: test
+        command: test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "circadian_tools"
 path = "src/lib.rs"
 
 [dependencies]
-chrono = "0.4.23"
+chrono = { version = "0.4.23", optional = true }
 num-traits = { version = "0.2" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ exclude = [
 name = "circadian_tools"
 path = "src/lib.rs"
 
+[features]
+default = ["chrono"]
+
 [dependencies]
 chrono = { version = "0.4.23", optional = true }
 num-traits = { version = "0.2" }

--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -1,0 +1,30 @@
+// This crate provides a function for getting circadian averages.
+use chrono::{self, NaiveTime, Timelike};
+
+pub fn avg_time_of_day<I, T>(data: I) -> NaiveTime
+where
+    I: Iterator<Item = T>,
+    T: Timelike,
+{
+    let data = data
+        .map(|x| x.num_seconds_from_midnight() as f64);
+
+    let avg_time = crate::circadian_average(86400.0, data).0;
+    NaiveTime::from_num_seconds_from_midnight_opt(avg_time as u32, 0).unwrap()
+}
+
+#[cfg(test)]
+mod avg_time_tests {
+    use super::*;
+    use chrono::NaiveTime;
+
+    #[test]
+    fn test_avg_time_of_day() {
+        let data = vec![
+            NaiveTime::from_hms_opt(1, 0, 0).unwrap(),
+            NaiveTime::from_hms_opt(23, 0, 0).unwrap(),
+        ];
+        let avg_time = avg_time_of_day(data.into_iter());
+        assert_eq!(avg_time, NaiveTime::from_hms_opt(0, 0, 0).unwrap());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,10 @@ use std::f64::consts::TAU;
 
 use num_traits::Float;
 
-// This crate provides a function for getting circadian averages.
-use chrono::{self, NaiveTime, Timelike};
+#[cfg(feature = "chrono")]
+mod chrono;
+#[cfg(feature = "chrono")]
+pub use crate::chrono::avg_time_of_day;
 
 pub fn circadian_average<I, F>(range: F, data: I) -> (F, F)
 where
@@ -37,18 +39,6 @@ where
     // Get the confidence, which is the distance of the average from the origin
     let confidence = (avg_x_pos.powi(2) + avg_y_pos.powi(2)).sqrt();
     (avg_value, confidence)
-}
-
-pub fn avg_time_of_day<I, T>(data: I) -> NaiveTime
-where
-    I: Iterator<Item = T>,
-    T: Timelike,
-{
-    let data = data
-        .map(|x| x.num_seconds_from_midnight() as f64);
-
-    let avg_time = circadian_average(86400.0, data).0;
-    NaiveTime::from_num_seconds_from_midnight_opt(avg_time as u32, 0).unwrap()
 }
 
 #[cfg(test)]
@@ -88,21 +78,5 @@ mod tests {
         let (avg, confidence) = circadian_average(4.0, data.into_iter());
         assert!(approx_eq!(f64, avg, 1.0, epsilon = 0.0001));
         assert!(approx_eq!(f64, confidence, 0.0, epsilon = 0.0001));
-    }
-}
-
-#[cfg(test)]
-mod avg_time_tests {
-    use super::*;
-    use chrono::NaiveTime;
-
-    #[test]
-    fn test_avg_time_of_day() {
-        let data = vec![
-            NaiveTime::from_hms_opt(1, 0, 0).unwrap(),
-            NaiveTime::from_hms_opt(23, 0, 0).unwrap(),
-        ];
-        let avg_time = avg_time_of_day(data.into_iter());
-        assert_eq!(avg_time, NaiveTime::from_hms_opt(0, 0, 0).unwrap());
     }
 }


### PR DESCRIPTION
Since the functionality of this crate does not require chrono, this PR makes it optional. If need be, chrono can be enabled by default.