### PR TITLE
Negative output

### DIFF
--- a/src/chrono.rs
+++ b/src/chrono.rs
@@ -6,8 +6,7 @@ where
     I: Iterator<Item = T>,
     T: Timelike,
 {
-    let data = data
-        .map(|x| x.num_seconds_from_midnight() as f64);
+    let data = data.map(|x| x.num_seconds_from_midnight() as f64);
 
     let avg_time = crate::circadian_average(86400.0, data).0;
     NaiveTime::from_num_seconds_from_midnight_opt(avg_time as u32, 0).unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ where
     let tau_over_range = tau / range;
 
     for x in data {
+        assert!(x >= F::zero(), "Input data must be positive");
         len += 1;
         // Get X, Y position of each data point on a circle with a perimeter of range
         let angle = x * tau_over_range;
@@ -53,6 +54,13 @@ mod tests {
     use super::*;
     use float_cmp::approx_eq;
     use std::f64::consts::FRAC_1_SQRT_2;
+
+    #[test]
+    #[should_panic]
+    fn negative_input_fails() {
+        let data = vec![-1.0];
+        let _ = circadian_average(4.0, data.into_iter());
+    }
 
     #[test]
     fn test_circadian_average_unanimous() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::f64::consts::TAU;
+use std::{f64::consts::TAU, fmt::{Debug, Display}};
 
 use num_traits::Float;
 
@@ -9,21 +9,21 @@ pub use crate::chrono::avg_time_of_day;
 
 pub fn circadian_average<I, F>(range: F, data: I) -> (F, F)
 where
-    F: Float,
+    F: Float + Debug + Display,
     I: Iterator<Item = F>,
 {
     let mut len = 0;
     let mut x_pos_sum = F::zero();
     let mut y_pos_sum = F::zero();
-    
+
     // This unwrap is reasonable as this can not be done if F can't be represented as 2PI
     let tau = F::from(TAU).unwrap();
-    let dist_to_angle = tau / range;
+    let tau_over_range = tau / range;
 
     for x in data {
         len += 1;
         // Get X, Y position of each data point on a circle with a perimeter of range
-        let angle = x * dist_to_angle;
+        let angle = x * tau_over_range;
         let (s, c) = angle.sin_cos();
         x_pos_sum = x_pos_sum + c;
         y_pos_sum = y_pos_sum + s;
@@ -31,13 +31,18 @@ where
 
     let avg_x_pos = x_pos_sum / F::from(len).unwrap();
     let avg_y_pos = y_pos_sum / F::from(len).unwrap();
-
     // Get the angle of the average position
-    let avg_angle = avg_y_pos.atan2(avg_x_pos);
+    let atan2 = avg_y_pos.atan2(avg_x_pos);
+    let avg_angle = if atan2 < F::zero() {
+        atan2 + tau
+    } else {
+        atan2
+    };
     // Convert the angle to a value on the range
-    let avg_value = avg_angle / dist_to_angle;
+    let avg_value = avg_angle / tau_over_range;
     // Get the confidence, which is the distance of the average from the origin
     let confidence = (avg_x_pos.powi(2) + avg_y_pos.powi(2)).sqrt();
+    println!("Average: {avg}, Error: {confidence}, Avg Value: {avg_value}", avg = avg_angle, confidence = confidence, avg_value = avg_value);
     (avg_value, confidence)
 }
 
@@ -59,7 +64,7 @@ mod tests {
     fn test_circadian_crossing_zero() {
         let data = vec![0.5, 3.5];
         let (avg, confidence) = circadian_average(4.0, data.into_iter());
-        assert!(approx_eq!(f64, avg, 0.0, epsilon = 0.0001));
+        assert!(approx_eq!(f64, avg, 4.0, epsilon = 0.0001));
         assert!(approx_eq!(f64, confidence, FRAC_1_SQRT_2, epsilon = 0.0001));
     }
 
@@ -79,4 +84,27 @@ mod tests {
         assert!(approx_eq!(f64, avg, 1.0, epsilon = 0.0001));
         assert!(approx_eq!(f64, confidence, 0.0, epsilon = 0.0001));
     }
+
+    #[test]
+    fn test_average_in_lower_left_quadrant() {
+        let data = vec![2.0, 3.0];
+        let (avg, confidence) = circadian_average(4.0, data.into_iter());
+        assert!(approx_eq!(f64, avg, 2.5, epsilon = 0.0001));
+        assert!(approx_eq!(f64, confidence, FRAC_1_SQRT_2, epsilon = 0.0001));
+    }
+
+    // #[test]
+    // fn avg_count() {
+    //     const FACTOR: f64 = 607.0;
+    //     let data: Vec<f64> = vec![
+    //         514.0, 176.0, 64.0, 249.0, 415.0, 455.0, 221.0, 375.0, 477.0, 464.0, 421.0, 32.0, 40.0, 496.0, 534.0, 134.0,
+    //     ];
+    //     let inputs = data.into_iter().map(|x| x);
+    //     println!("inputs: {:?}", inputs);
+    //     let (avg, _) = circadian_average(
+    //         FACTOR,
+    //         inputs,
+    //     );
+    //     assert_eq!(avg, -108.24684679858052);
+    // }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,6 @@ where
     let avg_value = avg_angle / tau_over_range;
     // Get the confidence, which is the distance of the average from the origin
     let confidence = (avg_x_pos.powi(2) + avg_y_pos.powi(2)).sqrt();
-    println!("Average: {avg}, Error: {confidence}, Avg Value: {avg_value}", avg = avg_angle, confidence = confidence, avg_value = avg_value);
     (avg_value, confidence)
 }
 
@@ -72,7 +71,6 @@ mod tests {
     fn test_circadian_average_split() {
         let data = vec![1.0, 2.0];
         let (avg, confidence) = circadian_average(4.0, data.into_iter());
-        println!("Average: {avg}, Error: {confidence}");
         assert_eq!(avg, 1.5);
         assert!(approx_eq!(f64, confidence, FRAC_1_SQRT_2, epsilon = 0.0001));
     }
@@ -93,18 +91,18 @@ mod tests {
         assert!(approx_eq!(f64, confidence, FRAC_1_SQRT_2, epsilon = 0.0001));
     }
 
-    // #[test]
-    // fn avg_count() {
-    //     const FACTOR: f64 = 607.0;
-    //     let data: Vec<f64> = vec![
-    //         514.0, 176.0, 64.0, 249.0, 415.0, 455.0, 221.0, 375.0, 477.0, 464.0, 421.0, 32.0, 40.0, 496.0, 534.0, 134.0,
-    //     ];
-    //     let inputs = data.into_iter().map(|x| x);
-    //     println!("inputs: {:?}", inputs);
-    //     let (avg, _) = circadian_average(
-    //         FACTOR,
-    //         inputs,
-    //     );
-    //     assert_eq!(avg, -108.24684679858052);
-    // }
+    #[test]
+    fn avg_count() {
+        const FACTOR: f64 = 607.0;
+        let data: Vec<f64> = vec![
+            514.0, 176.0, 64.0, 249.0, 415.0, 455.0, 221.0, 375.0, 477.0, 464.0, 421.0, 32.0, 40.0, 496.0, 534.0, 134.0,
+        ];
+        let inputs = data.into_iter().map(|x| x);
+        let (avg, confidence) = circadian_average(
+            FACTOR,
+            inputs,
+        );
+        assert_eq!(avg, 498.7531532014195);
+        assert_eq!(confidence, 0.23138448716890458)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
-use std::{f64::consts::TAU, fmt::{Debug, Display}};
+use std::{
+    f64::consts::TAU,
+    fmt::{Debug, Display},
+};
 
 use num_traits::Float;
 
@@ -95,13 +98,11 @@ mod tests {
     fn avg_count() {
         const FACTOR: f64 = 607.0;
         let data: Vec<f64> = vec![
-            514.0, 176.0, 64.0, 249.0, 415.0, 455.0, 221.0, 375.0, 477.0, 464.0, 421.0, 32.0, 40.0, 496.0, 534.0, 134.0,
+            514.0, 176.0, 64.0, 249.0, 415.0, 455.0, 221.0, 375.0, 477.0, 464.0, 421.0, 32.0, 40.0,
+            496.0, 534.0, 134.0,
         ];
         let inputs = data.into_iter().map(|x| x);
-        let (avg, confidence) = circadian_average(
-            FACTOR,
-            inputs,
-        );
+        let (avg, confidence) = circadian_average(FACTOR, inputs);
         assert_eq!(avg, 498.7531532014195);
         assert_eq!(confidence, 0.23138448716890458)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ mod tests {
     use std::f64::consts::FRAC_1_SQRT_2;
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "Input data must be positive")]
     fn negative_input_fails() {
         let data = vec![-1.0];
         let _ = circadian_average(4.0, data.into_iter());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,12 +36,10 @@ where
     let avg_x_pos = x_pos_sum / F::from(len).unwrap();
     let avg_y_pos = y_pos_sum / F::from(len).unwrap();
     // Get the angle of the average position
-    let atan2 = avg_y_pos.atan2(avg_x_pos);
-    let avg_angle = if atan2 < F::zero() {
-        atan2 + tau
-    } else {
-        atan2
-    };
+    let mut avg_angle = avg_y_pos.atan2(avg_x_pos);
+    if avg_angle < F::zero() {
+        avg_angle = avg_angle + tau;
+    }
     // Convert the angle to a value on the range
     let avg_value = avg_angle / tau_over_range;
     // Get the confidence, which is the distance of the average from the origin


### PR DESCRIPTION
The average function was pretty seriously broken. The atan2 function would return negative responses for the lower half of the unit circle that were `(desired_answer - TAU)`. I'll publish a new version of the crate since the crate is actually broken as published.